### PR TITLE
get rid of maven error messages in case of some build setups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,15 @@
             </execution>
           </executions>
         </plugin>
-
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.0</version>
+            <configuration>
+                <source>1.5</source>
+                <target>1.5</target>
+            </configuration>
+        </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
xdong@:zooinspector$ mvn compile
[INFO] Scanning for projects...
[INFO]  
[INFO] ------------------------------------------------------------------------
[INFO] Building zooinspector 1.0-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-resources-plugin:2.3:resources (default-resources) @ zooinspector ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 18 resources
[INFO] 
[INFO] --- maven-compiler-plugin:2.0.2:compile (default-compile) @ zooinspector ---
[INFO] Compiling 30 source files to /home/xdong/git/zooinspector/target/classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 2.359s
[INFO] Finished at: Tue Jun 30 16:59:55 PDT 2015
[INFO] Final Memory: 6M/31M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.0.2:compile (default-compile) on project zooinspector: Compilation failure: Compilation failure:
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/ZooInspectorUtil.java:[35,20] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/ZooInspectorUtil.java:[42,27] error: enhanced for loops are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable for-each loops)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/manager/ZooInspectorReadOnlyManager.java:[43,23] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/nodeviewer/NodeViewerData.java:[132,7] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable annotations)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/nodeviewer/NodeViewerData.java:[228,39] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/ZooInspectorNodeViewersPanel.java:[43,22] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/ZooInspectorNodeViewersPanel.java:[82,47] error: enhanced for loops are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable for-each loops)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/ZooInspectorNodeViewersPanel.java:[107,5] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable annotations)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/retry/ZooKeeperRetry.java:[69,5] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable annotations)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/retry/ZooKeeperRetry.java:[76,55] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/encryption/BasicDataEncryptionManager.java:[32,5] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable annotations)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/ZooInspectorConnectionPropertiesDialog.java:[56,25] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/ZooInspectorConnectionPropertiesDialog.java:[91,47] error: enhanced for loops are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable for-each loops)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/ZooInspectorConnectionPropertiesDialog.java:[130,19] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable annotations)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/ZooInspectorNodeViewersDialog.java:[88,22] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/ZooInspectorNodeViewersDialog.java:[105,43] error: enhanced for loops are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable for-each loops)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/ZooInspectorNodeViewersDialog.java:[110,13] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable annotations)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/NodeViewersChangeListener.java:[36,39] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/ZooInspectorPanel.java:[57,22] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/ZooInspectorPanel.java:[88,34] error: enhanced for loops are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable for-each loops)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/ZooInspectorPanel.java:[139,13] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable annotations)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/NodeDataViewerFindDialog.java:[63,7] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable annotations)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/manager/ZooInspectorManager.java:[61,15] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/manager/ZooInspectorManagerImpl.java:[113,11] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/manager/ZooInspectorManagerImpl.java:[144,3] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable annotations)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/manager/ZooInspectorManagerImpl.java:[329,29] error: enhanced for loops are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable for-each loops)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/manager/ZooInspectorManagerCache.java:[16,11] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/manager/ZooInspectorManagerCache.java:[68,28] error: enhanced for loops are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable for-each loops)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/manager/NodeListener.java:[36,15] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/ZooInspectorTreeViewer.java:[75,21] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/ZooInspectorTreeViewer.java:[99,13] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable annotations)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/ZooInspectorTreeViewer.java:[214,33] error: enhanced for loops are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable for-each loops)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/nodeviewer/ZooInspectorNodeViewer.java:[56,50] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/nodeviewer/ZooInspectorNodeViewer.java:[104,5] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable annotations)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/ListInput.java:[56,7] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable annotations)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/nodeviewer/NodeViewerMetaData.java:[68,5] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable annotations)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/nodeviewer/NodeViewerMetaData.java:[81,41] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/nodeviewer/NodeViewerMetaData.java:[120,57] error: enhanced for loops are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable for-each loops)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/nodeviewer/NodeViewerACL.java:[66,5] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable annotations)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/nodeviewer/NodeViewerACL.java:[79,41] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/gui/nodeviewer/NodeViewerACL.java:[113,50] error: enhanced for loops are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable for-each loops)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/ZooInspector.java:[63,17] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable annotations)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/manager/Pair.java:[26,17] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR](use -source 5 or higher to enable generics)
[ERROR] /home/xdong/git/zooinspector/src/main/java/org/apache/zookeeper/inspector/manager/Pair.java:[74,5] error: annotations are not supported in -source 1.3
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
xdong@:zooinspector$
